### PR TITLE
Update base64mix-1.0.0-1.rockspec

### DIFF
--- a/rockspecs/base64mix-1.0.0-1.rockspec
+++ b/rockspecs/base64mix-1.0.0-1.rockspec
@@ -1,7 +1,7 @@
 package = "base64mix"
 version = "1.0.0-1"
 source = {
-    url = "git://github.com/mah0x211/lua-base64mix.git",
+    url = "git+https://github.com/mah0x211/lua-base64mix.git",
     tag = 'v1.0.0'
 }
 description = {


### PR DESCRIPTION
As per `https://github.blog/2021-09-01-improving-git-protocol-security-github/` unauthenticated `git://` protocol is no longer supported. Below is the timeline for the same:

> January 11, 2022	Final brownout.
This is the full brownout period where we’ll temporarily stop accepting the deprecated key and signature types, ciphers, and MACs, and the unencrypted Git protocol. This will help clients discover any lingering use of older keys or old URLs. 

Due to this lua module installation has started failing from today with following error:

```bash
Cloning into 'lua-base64mix'...

fatal: remote error: 

  The unauthenticated git protocol on port 9418 is no longer supported.

Please see https://github.blog/2021-09-01-improving-git-protocol-security-github/ for more information.



Error: Failed cloning git repository.

Installing https://luarocks.org/lrexlib-pcre-2.9.0-1.src.rock
```