### PR TITLE
Use errno module instead of strerror function

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@ base64 encode/decode module.
 luarocks install base64mix
 ```
 
+## Error Handling
+
+the following functions return an `error` object created by https://github.com/mah0x211/lua-errno module.
+
 
 ## str, err = base64mix.encode( src:string )
 

--- a/rockspecs/base64mix-scm-1.rockspec
+++ b/rockspecs/base64mix-scm-1.rockspec
@@ -11,6 +11,7 @@ description = {
 }
 dependencies = {
     "lua >= 5.1",
+    "errno >= 0.5.0",
 }
 build = {
     type = "make",


### PR DESCRIPTION
This pull request introduces enhancements to error handling and code organization in the `base64mix` library. It replaces the use of `strerror` for error messages with the `lua_errno` library, updates the `rockspec` dependencies, and refactors the way Lua functions are exported to improve readability and maintainability.

### Error Handling Enhancements:
* Replaced `strerror(errno)` with `lua_errno_new` for creating structured error objects in `encode_std_lua`, `encode_url_lua`, and `decode_mix_lua` functions. This improves error reporting by providing more context. [[1]](diffhunk://#diff-a2aee9863c6c91fa4fe4c6786c33458dc7f60a16b5d80f1b36f6ed8050a50e5eL56-R51) [[2]](diffhunk://#diff-a2aee9863c6c91fa4fe4c6786c33458dc7f60a16b5d80f1b36f6ed8050a50e5eL81-R76)

### Dependency Updates:
* Added `errno >= 0.5.0` as a dependency in the `rockspec` file to support the new error handling mechanism.

### Code Organization Improvements:
* Refactored the inclusion of headers in `src/base64.c` by reorganizing system headers and replacing `<errno.h>` with `"lua_errno.h"`. This ensures compatibility with the `lua_errno` library.
* Replaced the macro `lstate_fn2tbl` with explicit calls to `lua_pushcfunction` and `lua_setfield` for exporting Lua functions, making the code easier to read and maintain.
* Added a call to `lua_errno_loadlib` to initialize the `lua_errno` library for error handling.